### PR TITLE
Question Bank Support Implemented

### DIFF
--- a/src/helpers.py
+++ b/src/helpers.py
@@ -10,6 +10,7 @@ Monday, April 06, 2020
 
 from util import shut_down
 import pandas as pd
+import settings
 import requests
 import settings
 import random
@@ -19,7 +20,29 @@ import json
 import io
 
 
-def get_essay_question_ids(questions):
+def get_all_essay_question_ids(quiz_questions):
+
+    # get the ones in the quiz (not in question banks!)
+    essay_question_ids = _get_essay_question_ids(quiz_questions)
+
+    if settings.has_question_bank:
+        print('Getting question data from Question Bank...')
+        # get all quiz submissions
+        submissions = settings.quiz.get_all_quiz_submissions()
+        for sub in submissions:
+            submission_questions = sub.get_submission_questions()
+
+            submission_essay_question_ids = _get_essay_question_ids(
+                submission_questions)
+
+            for question_id in submission_essay_question_ids:
+                if question_id not in essay_question_ids:
+                    essay_question_ids.append(question_id)
+
+    return essay_question_ids
+
+
+def _get_essay_question_ids(questions):
     essay_questions = filter(
         lambda q: (q.question_type == 'essay_question'),
         questions

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -5,7 +5,7 @@ authors:
 @markoprodanovic
 
 last edit:
-Monday, April 06, 2020
+Monday, May 04, 2020
 """
 
 from util import shut_down

--- a/src/interface.py
+++ b/src/interface.py
@@ -66,20 +66,29 @@ def get_user_inputs():
         shut_down(
             f'ERROR: Quiz not found [ID: {quiz_id}]. Please check quiz number.')
 
+    question_bank_input = input('Does this quiz use Question Bank(s)? [y/n]: ')
+
+    if question_bank_input is 'y' or question_bank_input is 'Y':
+        has_question_bank = True
+    else:
+        has_question_bank = False
+
     # prompt user for confirmation
-    _prompt_for_confirmation(user.name, course.name, quiz.title)
+    _prompt_for_confirmation(user.name, course.name,
+                             quiz.title, has_question_bank)
 
     # set course, quiz, students and auth_header as global variables
     settings.course = course
     settings.quiz = quiz
     settings.students = students
     settings.auth_header = auth_header
+    settings.has_question_bank = has_question_bank
 
     # return inputs dictionary
     return url, course_id, quiz_id
 
 
-def _prompt_for_confirmation(user_name, course_name, quiz_title):
+def _prompt_for_confirmation(user_name, course_name, quiz_title, has_question_bank):
     """Prints user inputs to screen and asks user to confirm. Shuts down if user inputs
     anything other than 'Y' or 'y'. Returns otherwise.
 
@@ -96,10 +105,11 @@ def _prompt_for_confirmation(user_name, course_name, quiz_title):
     print(f'USER:  {user_name}')
     print(f'COURSE:  {course_name}')
     print(f'QUIZ:  {quiz_title}')
+    print(f'HAS QUESTION BANK: {has_question_bank}')
     print('\n')
 
     confirm = input(
-        'Would you like to continue using the above information?[y/n]: ')
+        'Would you like to continue using the above information? [y/n]: ')
 
     print('\n')
 

--- a/src/interface.py
+++ b/src/interface.py
@@ -5,7 +5,7 @@ authors:
 @markoprodanovic
 
 last edit:
-Wednesday, April 01, 2020
+Monday, May 04, 2020
 """
 
 import getpass

--- a/src/pdf_helpers.py
+++ b/src/pdf_helpers.py
@@ -5,12 +5,11 @@ authors:
 @markoprodanovic
 
 last edit:
-Monday, April 06, 2020
+Monday, May 04, 2020
 """
 
 from reportlab.pdfgen import canvas as pdfcanvas
 import settings
-import math
 
 
 def generate_pdf(row, cols, title, pdf_dir_path, anonymous_id):

--- a/src/pdf_helpers.py
+++ b/src/pdf_helpers.py
@@ -10,6 +10,7 @@ Monday, April 06, 2020
 
 from reportlab.pdfgen import canvas as pdfcanvas
 import settings
+import math
 
 
 def generate_pdf(row, cols, title, pdf_dir_path, anonymous_id):
@@ -38,8 +39,10 @@ def generate_pdf(row, cols, title, pdf_dir_path, anonymous_id):
         text.textLine(' ')
         lines += 1
 
-        # add student response
-        text, lines, pdf = wrap_text_line(text, str(row[c]), lines, pdf)
+        # add student response if one is there, otherwise print a blank below the question
+        if str(row[c]) != 'nan':
+            text, lines, pdf = wrap_text_line(text, str(row[c]), lines, pdf)
+
         pdf.drawText(text)
 
         # add page break for next question/response

--- a/src/quiz_reports.py
+++ b/src/quiz_reports.py
@@ -8,7 +8,7 @@ last edit:
 Monday, April 06, 2020
 """
 
-from helpers import (get_essay_question_ids, create_quiz_report,
+from helpers import (get_all_essay_question_ids, create_quiz_report,
                      get_progress, download_quiz_report, generate_random_id)
 from pdf_helpers import generate_pdf, wrap_text_line, draw_my_ruler
 # from reportlab.pdfgen import canvas as pdfcanvas
@@ -40,8 +40,8 @@ def main():
     url, course_id, quiz_id = get_user_inputs()
 
     # get quiz questions and save ids of essay questions
-    questions = settings.quiz.get_questions()
-    essay_question_ids = get_essay_question_ids(questions)
+    quiz_questions = settings.quiz.get_questions()
+    essay_question_ids = get_all_essay_question_ids(quiz_questions)
 
     # create a new quiz report on Canvas
     try:

--- a/src/quiz_reports.py
+++ b/src/quiz_reports.py
@@ -5,7 +5,7 @@ authors:
 @markoprodanovic
 
 last edit:
-Monday, April 06, 2020
+Monday, May 04, 2020
 """
 
 from helpers import (get_all_essay_question_ids, create_quiz_report,
@@ -41,6 +41,8 @@ def main():
 
     # get quiz questions and save ids of essay questions
     quiz_questions = settings.quiz.get_questions()
+
+    # get list of ids of all essay question (in Quiz and in Quiz Banks if used)
     essay_question_ids = get_all_essay_question_ids(quiz_questions)
 
     # create a new quiz report on Canvas

--- a/src/settings.py
+++ b/src/settings.py
@@ -24,3 +24,6 @@ def init():
 
     # Authorization for API Calls
     global auth_header
+
+    # Does this quiz use question bank(s) (default: false)
+    global has_question_bank

--- a/src/settings.py
+++ b/src/settings.py
@@ -7,7 +7,7 @@ authors:
 @markoprodanovic
 
 last edit:
-Wednesday, April 03, 2020
+Monday, May 04, 2020
 """
 
 


### PR DESCRIPTION
**Would close #22**

* UI prompts user to specify whether the quiz uses Question Banks [y/n]
* If quiz **does not** use question banks, all questions (individual and groups) are fetched from Quiz like before
* If quiz **does** use question banks, quiz questions are fetched as above, then we iterate through each individual submission and check _those_ questions. If we find questions with `type = 'essay_question'`that we haven't accounted for, we add them to our list of id's to include in our output.

> Note: This fix is not very efficient (which is why users are asked to specify _if_ there is a Question Bank). The Canvas API doesn't seem to provide a better way of getting Questions out of Question Banks so this is the best we can do for now.