### PR TITLE
Added version for canvasapi and renamed environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ _Are you Sauder Operations Staff? Please go [here](sauder-ops-guide.md) for deta
 1. Import environment: `$ conda env create -f environment.yml`
 
 1. Run:
-   1. `$ conda activate quiz_reports_env`
+   1. `$ conda activate quiz-reports`
    1. `$ jupyter notebook`
    1. Select **Kernal** > **Restart & Run All**

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: quiz_reports_env
+name: quiz-reports
 channels:
   - conda-forge
   - anaconda
@@ -12,4 +12,4 @@ dependencies:
   - pandas
   - pip
   - pip:
-      - canvasapi
+      - canvasapi==0.15.0


### PR DESCRIPTION
Set canvasapi version: `canvasapi==0.15.0`

To allow us to continue to use .attributes syntax until the tool has been updated to remove (depreciated syntax)